### PR TITLE
Fix MySQL compatibility: boolean values, timestamp format, insert pla…

### DIFF
--- a/src/main/java/org/battleplugins/tracker/sql/TrackerSqlSerializer.java
+++ b/src/main/java/org/battleplugins/tracker/sql/TrackerSqlSerializer.java
@@ -7,7 +7,6 @@ import org.battleplugins.tracker.stat.StatType;
 import org.battleplugins.tracker.stat.TallyEntry;
 import org.battleplugins.tracker.stat.VersusTally;
 import org.jetbrains.annotations.Blocking;
-// Add for MySQL format
 import java.sql.Timestamp;
 
 import java.sql.ResultSet;
@@ -255,9 +254,7 @@ public class TrackerSqlSerializer extends SqlSerializer {
                 String[] tallyObjectArray = new String[4];
                 tallyObjectArray[0] = entry.id1().toString();
                 tallyObjectArray[1] = entry.id2().toString();
-                // Required for correct boolean format in MySQL (use "1"/"0" instead of "true"/"false")
                 tallyObjectArray[2] = entry.tie() ? "1" : "0";
-                // Required because MySQL expects a DATETIME string, not a raw timestamp.
                 tallyObjectArray[3] = Timestamp.from(entry.timestamp()).toString();
 
                 // Use Arrays.asList instead of List.of to correctly convert the String[] into a List<String>
@@ -322,7 +319,6 @@ public class TrackerSqlSerializer extends SqlSerializer {
         StringBuilder builder = new StringBuilder();
         switch (this.getType()) {
             case MYSQL:
-                // Fixed an issue where 6 values were attempted to be inserted, causing a mismatch with the expected number of columns
                 String insertOverall = "INSERT INTO " + this.versusTable + " VALUES (?, ?, ";
                 builder.append(insertOverall);
                 for (int i = 0; i < this.versusColumns.size(); i++) {
@@ -364,7 +360,6 @@ public class TrackerSqlSerializer extends SqlSerializer {
 
     private String constructInsertTallyStatement() {
         return switch (this.getType()) {
-            // idk why but When disconnecting, the same row may be inserted multiple times with identical data. INSERT IGNORE avoids duplicate PRIMARY KEY errors.
             case MYSQL -> "INSERT IGNORE INTO " + this.tallyTable + " VALUES (?, ?, ?, ?)";
             case SQLITE -> "INSERT OR REPLACE INTO " + this.tallyTable + " VALUES (?, ?, ?, ?)";
         };


### PR DESCRIPTION
Description :
As discussed on Discord earlier, this pull request fixes several compatibility issues encountered when using MySQL with the plugin.

🔧 Changes include:
	•	Replacing Boolean.toString() with "1" / "0" to properly store BOOLEAN values in MySQL.
	•	Converting epoch millis (Instant) to SQL Timestamp to match the expected format for TIMESTAMP columns.
	•	Correcting a mismatch where 6 values were provided in the batch insert for bt_pvp_versus, while only 5 columns existed in the statement.
	•	Using Arrays.asList(...) instead of List.of(...) to prevent runtime exceptions when passing arrays.
	•	Commented all modified lines to clarify the purpose of each change and facilitate review.

✅ After these modifications, no more SQL-related errors occur during player disconnect or batch insert operations.

Let me know if any adjustment is needed!